### PR TITLE
PART 3 Leap second parsing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@ pub struct LeapSecond {
     pub timestamp: i32,
 
     /// Number of leap seconds to be added.
-    pub leap_second_count: u32,
+    pub leap_second_count: i32,
 }
 
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -85,7 +85,7 @@ pub struct LeapSecondData {
     pub timestamp: i32,
 
     /// Number of leap seconds to be added.
-    pub leap_second_count: u32,
+    pub leap_second_count: i32,
 }
 
 
@@ -256,7 +256,7 @@ impl Parser {
         for _ in 0 .. count {
             buf.push(LeapSecondData {
                 timestamp:          self.cursor.read_i32::<BigEndian>()?,
-                leap_second_count:  self.cursor.read_u32::<BigEndian>()?,
+                leap_second_count:  self.cursor.read_i32::<BigEndian>()?,
             });
         }
         Ok(buf)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -374,8 +374,8 @@ pub fn parse(buf: Vec<u8>, limits: Limits) -> Result<TZData> {
 
     let transitions    = parser.read_transition_data(header.num_transitions as usize)?;
     let time_info      = parser.read_local_time_type_data(header.num_local_time_types as usize)?;
-    let leap_seconds   = parser.read_leap_second_data(header.num_leap_seconds as usize)?;
     let strings        = parser.read_octets(header.num_abbr_chars as usize)?;
+    let leap_seconds   = parser.read_leap_second_data(header.num_leap_seconds as usize)?;
     let standard_flags = parser.read_octets(header.num_standard_flags as usize)?;
     let gmt_flags      = parser.read_octets(header.num_gmt_flags as usize)?;
 


### PR DESCRIPTION
This PR changes leap seconds to signed, and reorders parsing to handle files with leap seconds correctly. The Earth has never gone faster a leap second though the system's in place for it (checked glibc's `tzfile.c` as well and it's signed too as a `long int`). Parsing zones with leap seconds in `/usr/share/zoneinfo/right/` with the `tzdump` example now parses correctly.

Most of the pc world sticks with no leap second insanity anyways and possibly a negative would never happen unless an asteroid hits or something so this is all kind of minor, but hopefully it'll help users and readers out there :)