### PR TITLE
Fixed unstable copied issue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,5 @@ name = "zoneinfo_compiled"
 [dependencies]
 byteorder = "1"
 datetime = "0.4.7"
+
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![crate_name = "zoneinfo_compiled"]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
+#![feature(copied)]
 
 //! This is a library for parsing compiled zoneinfo files.
 


### PR DESCRIPTION
This PR fixes the 'use of unstable library feature' issue detailed here https://github.com/rust-datetime/zoneinfo-compiled/issues/9.

